### PR TITLE
Allow to specify own environment "PATH" for @PlatformIO command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+* Allowed to specify own environment `PATH` for `platformio` command.
+  By default `PATH` is set to value from the currrent Atom session.
+
 ## 0.2.0
 * Logging output in a much nicer format
 * Added settings for verbose outputs

--- a/README.md
+++ b/README.md
@@ -1,40 +1,50 @@
 # platomformio
 
 Integration with [PlatformIO](http://platformio.org/) cross-platform code
-builder and the missing library manager (Ready for embedded development, Continuous integration, Arduino and MBED compatible).
+builder and the missing library manager (Ready for embedded development,
+Continuous integration, Arduino and MBED compatible).
 
-##Setup
+## Setup
 - Install [PlatformIO](http://platformio.org/)
-  - by default, this package expects the `platformio` command to be available at `usr/local/bin/platformio`. You can update this in the package settings.
-- Create a PlatformIO project (just a folder structure with `src/`, `lib/`, and a `platformio.ini` file).
+- Create a PlatformIO project using [platformio init](http://docs.platformio.org/en/latest/userguide/cmd_init.html) command:
   - `mkdir my-project; cd my-project`
   - `platformio init --board=uno` (answer no `N` to auto-uploading question)
-  - `touch src/blink.ino`
+  - copy your source files to `src` directory.
 
-##Build
+**Note!** If you have an error `Program "platformio" not found in PATH`,
+please specify "Environment PATH to run `platformio`" in settings.
+
+## Build
 
 Verify your code can compile with `cmd-shift-B`:
 
 ![build](http://i.imgur.com/6h1OSt7.gif)
 
-##Upload
+## Upload
 
 Plug your Arduino in and `cmd-shift-U`:
 
 ![upload](http://i.imgur.com/sYk6qAO.gif)
 
-##Kill Process
+## Kill Process
 
 You can kill a process anytime with `cmd-shift-k`
 
-##Settings
+## Settings
 
-- **Platformio path:** Defaults to `/usr/local/bin/platformio`. Can find your PlatformIO command path like so: `which platformio`.
+- **Environment PATH to run `platformio`:** Defaults to `PATH` from current
+  Atom session. `PATH` should contain directory where `platformio` is installed.
+  If you have an error `Program "platformio" not found in PATH`, then paste
+  here result of `echo $PATH` (Unix) / `echo %PATH%` (Windows) command by
+  typing into your terminal.
 
-- **Verbose Builds:** Default behavior is to only show build output if there is an error. Check this if you want to see all build output.
+- **Verbose Builds:** Default behavior is to only show build output if there is
+  an error. Check this if you want to see all build output.
 
-- **Verbose Uploads:** Default behavior is to show all upload output. Uncheck this if you only want to see output if there is an error.
+- **Verbose Uploads:** Default behavior is to show all upload output. Uncheck
+  this if you only want to see output if there is an error.
 
-###Acknowledgements
+### Acknowledgements
 
-*This package has [atom-script](https://github.com/rgbkrk/atom-script) to thank for it's good looks*
+*This package has [atom-script](https://github.com/rgbkrk/atom-script) to thank
+for it's good looks*

--- a/lib/platomformio-view.coffee
+++ b/lib/platomformio-view.coffee
@@ -55,6 +55,7 @@ class PlatomformioViewView extends View
     options =
       cwd: @getCwd()
       env: process.env
+    options.env.PATH = atom.config.get('platomformio.environPath')
 
     stdout = (output) => @display 'stdout', output
     stderr = (output) => @display 'stderr', output
@@ -79,12 +80,9 @@ class PlatomformioViewView extends View
       @error()
       @bufferedProcess = null
       @output.append $$ ->
-        if command == undefined
-          @h2 "Platformio path is undefined. Define in package settings."
-        else
-          @h1 "Unable to run command: \"#{command}\""
-          @pre "ERROR: #{nodeError.error.message}"
-          @pre "PATH: #{process.env.PATH}"
+        @h1 "Unable to run command: \"#{command}\""
+        @pre "ERROR: #{nodeError.error.message}"
+        @pre "PATH: #{process.env.PATH}"
 
       console.log(nodeError)
       nodeError.handle()

--- a/lib/platomformio.coffee
+++ b/lib/platomformio.coffee
@@ -11,11 +11,11 @@ module.exports = Platomformio =
       title: 'Show all upload output (default is to only show if an error occurs)'
       type: 'boolean'
       default: true
-    platformioPath:
-      title: 'Path for platformio command'
-      description: 'This package depends on platformio, find path by typing `which platformio` into your terminal'
+    environPath:
+      title: 'Environment PATH to run `platformio`'
+      description: '`PATH` should contain directory where `platformio` is installed. If you have an error `Program "platformio" not found in PATH`, then paste here result of `echo $PATH` (Unix) / `echo %PATH%` (Windows) command by typing into your terminal'
       type: 'string'
-      default: '/usr/local/bin/platformio'
+      default: process.env.PATH
   subscriptions: null
 
   activate: (state) ->
@@ -43,7 +43,7 @@ module.exports = Platomformio =
     if atom.config.get('platomformio.verboseBuild')
       @platomformioView.panel.addClass("descriptive")
 
-    @platomformioView.run(atom.config.get('platomformio.platformioPath'), ["--force", "run"])
+    @platomformioView.run("platformio", ["--force", "run"])
 
   upload: ->
     @saveWorkspace()
@@ -52,7 +52,7 @@ module.exports = Platomformio =
     if atom.config.get('platomformio.verboseUpload')
       @platomformioView.panel.addClass("descriptive")
 
-    @platomformioView.run(atom.config.get('platomformio.platformioPath'), ["--force", "run", "--target=upload"])
+    @platomformioView.run("platformio", ["--force", "run", "--target=upload"])
 
   clean: ->
     @saveWorkspace()
@@ -61,7 +61,7 @@ module.exports = Platomformio =
     if atom.config.get('platomformio.verboseUpload')
       @platomformioView.panel.addClass("descriptive")
 
-    @platomformioView.run(atom.config.get('platomformio.platformioPath'), ["--force", "run", "--target=clean"])
+    @platomformioView.run("platformio", ["--force", "run", "--target=clean"])
 
   close: ->
     @platomformioView.close()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "platomformio",
   "main": "./lib/platomformio",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Integration with PlatformIO: a cross-platform code builder and the missing library manager",
   "keywords": [
     "PlatformIO",


### PR DESCRIPTION
Please re-test it. It should work by default on the most host OS without modify any settings. 

Also, I see that "Platomformio" commands don't show in " Command Palette" (Cmd+P) in Atom 1.0.9. Did they change API?

If you don't have any objections, please push new release. Thanks.
