### PR TITLE
Return parent folder when in /lib subfolder

### DIFF
--- a/lib/platomformio-view.coffee
+++ b/lib/platomformio-view.coffee
@@ -121,7 +121,11 @@ class PlatomformioViewView extends View
   getCwd: ->
     editor = atom.workspace.getActivePaneItem()
     file = editor.buffer.file
-    file.getParent().getParent().path
+    path = file.getParent().getParent().path
+    if path.endsWith '/lib'
+      path.slice 0, -4 # Return parent directory
+    else
+      path
 
   success: ->
     @headerView.title.text 'Success'


### PR DESCRIPTION
When developing a library (in `/lib`), it would be great to not have to move to the `.ino` file in the parent folder to build.
This PR launches the build in the parent folder (at the root of the project), when the build command is fired from the `/lib` subfolder.
