### PR TITLE
Try to save only text editors

### DIFF
--- a/lib/platomformio-view.coffee
+++ b/lib/platomformio-view.coffee
@@ -3,9 +3,9 @@ HeaderView        = require './header-view'
 {View, $$}        = require 'atom-space-pen-views'
 AnsiFilter        = require 'ansi-to-html'
 
-# Runs a portion of a script through an interpreter and displays it line by line
+
 module.exports =
-class PlatomformioViewView extends View
+class PlatomformioView extends View
   @bufferedProcess: null
   @results: ""
 

--- a/lib/platomformio.coffee
+++ b/lib/platomformio.coffee
@@ -70,5 +70,4 @@ module.exports = Platomformio =
     @platomformioView.kill()
 
   saveWorkspace: ->
-    paneItem = atom.workspace.getActivePaneItem()
-    paneItem.save()
+    atom.workspace.getActiveTextEditor()?.save()


### PR DESCRIPTION
Fix a bug: when the active pane item isn't an editor, Atom throws an error since it cannot be saved.
Also fix some misspellings.
